### PR TITLE
Specification says /var/log/heater not /var/log/status

### DIFF
--- a/makefile-tc-arm
+++ b/makefile-tc-arm
@@ -1,5 +1,4 @@
-BUILDROOT_HOME=/home/cclamb/buildroot-2016.11.1
-
+BUILDROOT_HOME=/home/vagrant/buildroot-2024.02.2
 CC=$(BUILDROOT_HOME)/output/host/usr/bin/arm-linux-gcc
 CFLAGS=--sysroot=$(BUILDROOT_HOME)/output/staging
 INCLUDES=
@@ -21,5 +20,5 @@ $(MAIN): $(OBJ)
 
 all: $(MAIN)
 
-clean: 
+clean:
 	$(RM) $(MAIN) *.o *~

--- a/tc_main.c
+++ b/tc_main.c
@@ -23,7 +23,7 @@
 
 static const char*  DAEMON_NAME     = "tcsimd";
 static const char*  TEMP_FILENAME   = "/tmp/temp";
-static const char*  STATE_FILENAME  = "/tmp/status";
+static const char*  STATE_FILENAME  = "/tmp/heater";
 static const char*  WORKING_DIR     = "/";
 
 static const long   SLEEP_DELAY     = 5;


### PR DESCRIPTION
Did you want to update this code base to use /var/log/heater ?  It looks like the thermocouple code is looking at /var/log/status instead.